### PR TITLE
Add basic herb farming calculator

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -172,9 +172,9 @@ checksum = "14c189c53d098945499cdfa7ecc63567cf3886b3332b312a5b4585d8d3a6a610"
 
 [[package]]
 name = "cc"
-version = "1.0.70"
+version = "1.0.71"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d26a6ce4b6a484fa3edb70f7efa6fc430fd2b87285fe8b84304fd0936faa0dc0"
+checksum = "79c2681d6594606957bbb8631c4b90a7fcaaa72cdb714743a437b156d6a7eedd"
 
 [[package]]
 name = "cexpr"
@@ -259,6 +259,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "245097e9a4535ee1e3e3931fcfcd55a796a44c643e8596ff6566d68f09b87bbc"
 
 [[package]]
+name = "convert_case"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6245d59a3e82a7fc217c5828a6692dbc6dfb63a0c8c90495621f7b9d79704a0e"
+
+[[package]]
 name = "crossbeam-utils"
 version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -288,6 +294,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2b2466559f260f48ad25fe6317b3c8dac77b5bdb5763ac7d9d6103530663bc90"
 dependencies = [
  "memchr",
+]
+
+[[package]]
+name = "derive_more"
+version = "0.99.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "40eebddd2156ce1bb37b20bbe5151340a31828b1f2d22ba4141f3531710e38df"
+dependencies = [
+ "convert_case",
+ "proc-macro2 1.0.29",
+ "quote 1.0.10",
+ "rustc_version",
+ "syn",
 ]
 
 [[package]]
@@ -587,6 +606,7 @@ dependencies = [
  "colored",
  "config",
  "csv",
+ "derive_more",
  "lazy_static",
  "num-format",
  "open",
@@ -595,6 +615,7 @@ dependencies = [
  "serde",
  "serde_json",
  "structopt",
+ "strum",
  "thiserror",
  "ureq",
  "version_check 0.9.3",
@@ -617,6 +638,15 @@ name = "percent-encoding"
 version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d4fd5641d01c8f18a23da7b6fe29298ff4b55afcccdf78973b24cf3175fee32e"
+
+[[package]]
+name = "pest"
+version = "2.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "10f4872ae94d7b90ae48754df22fd42ad52ce740b8f370b03da4835417403e53"
+dependencies = [
+ "ucd-trie",
+]
 
 [[package]]
 name = "prettytable-rs"
@@ -772,6 +802,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7ef03e0a2b150c7a90d01faf6254c9c48a41e95fb2a8c2ac1c6f0d2b9aefc342"
 
 [[package]]
+name = "rustc_version"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0dfe2087c51c460008730de8b57e6a320782fbfb312e1f4d520e6c6fae155ee"
+dependencies = [
+ "semver",
+]
+
+[[package]]
 name = "rustls"
 version = "0.19.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -804,6 +843,24 @@ checksum = "b362b83898e0e69f38515b82ee15aa80636befe47c3b6d3d89a911e78fc228ce"
 dependencies = [
  "ring",
  "untrusted",
+]
+
+[[package]]
+name = "semver"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f301af10236f6df4160f7c3f04eec6dbc70ace82d23326abad5edee88801c6b6"
+dependencies = [
+ "semver-parser",
+]
+
+[[package]]
+name = "semver-parser"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "00b0bef5b7f9e0df16536d3961cfb6e84331c065b4066afb39768d0e319411f7"
+dependencies = [
+ "pest",
 ]
 
 [[package]]
@@ -886,6 +943,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "strum"
+version = "0.21.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aaf86bbcfd1fa9670b7a129f64fc0c9fcbbfe4f1bc4210e9e98fe71ffc12cde2"
+dependencies = [
+ "strum_macros",
+]
+
+[[package]]
+name = "strum_macros"
+version = "0.21.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d06aaeeee809dbc59eb4556183dd927df67db1540de5be8d3ec0b6636358a5ec"
+dependencies = [
+ "heck",
+ "proc-macro2 1.0.29",
+ "quote 1.0.10",
+ "syn",
+]
+
+[[package]]
 name = "syn"
 version = "1.0.80"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -959,6 +1037,12 @@ name = "tinyvec_macros"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cda74da7e1a664f795bb1f8a87ec406fb89a02522cf6e50620d016add6dbbf5c"
+
+[[package]]
+name = "ucd-trie"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56dee185309b50d1f11bfedef0fe6d036842e3fb77413abef29f8f8d1c5d4c1c"
 
 [[package]]
 name = "unicode-bidi"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,32 +17,20 @@ path = "src/main.rs"
 [dependencies]
 anyhow = "^1.0.0"
 colored = "^2.0.0"
+config = {version = "^0.11.0", default-features = false, features = ["json"]}
 csv = "^1.1.3"
+derive_more = "^0.99.16"
 lazy_static = "^1.4.0"
+num-format = {version = "^0.4.0", features = ["with-system-locale"]}
 open = "^1.4.0"
 prettytable-rs = "^0.8.0"
 regex = "^1.3.9"
+serde = {version = "^1.0.114", features = ["derive"]}
 serde_json = "^1.0.57"
 structopt = "^0.3.15"
+strum = {version = "^0.21.0", features = ["derive"]}
 thiserror = "^1.0.0"
-
-[dependencies.config]
-default-features = false
-features = ["json"]
-version = "^0.11.0"
-
-[dependencies.num-format]
-features = ["with-system-locale"]
-version = "^0.4.0"
-
-[dependencies.serde]
-features = ["derive"]
-version = "^1.0.114"
-
-[dependencies.ureq]
-default-features = false
-features = ["tls"]
-version = "^2.0.1"
+ureq = {version = "^2.0.1", default-features = false, features = ["tls"]}
 
 [dev-dependencies]
 assert_approx_eq = "^1.1.0"

--- a/src/commands/calc/drop.rs
+++ b/src/commands/calc/drop.rs
@@ -3,7 +3,7 @@ use std::fmt::Display;
 use crate::{
     commands::Command,
     error::OsrsError,
-    utils::{context::CommandContext, math},
+    utils::{context::CommandContext, fmt, math},
 };
 use lazy_static::lazy_static;
 use regex::Regex;
@@ -163,8 +163,8 @@ impl Command for CalcDropCommand {
         );
 
         println!(
-            "{:.4}% chance of {} successes in {} attempts",
-            result_prob * 100.0,
+            "{} chance of {} successes in {} attempts",
+            fmt::fmt_probability_long(result_prob),
             self.target,
             self.iterations
         );

--- a/src/commands/calc/farm/herb.rs
+++ b/src/commands/calc/farm/herb.rs
@@ -1,0 +1,351 @@
+use crate::{
+    commands::Command,
+    config::{AnimaPlant, Compost, FarmingHerbsConfig, HerbPatch},
+    error::OsrsError,
+    utils::{context::CommandContext, fmt, math},
+};
+use derive_more::{Add, Display, Div, Sum};
+use prettytable::{cell, row, Table};
+use std::fmt::Display;
+use structopt::StructOpt;
+use strum::{EnumIter, IntoEnumIterator};
+
+// TODO add command for setting herb config more easily
+
+/// Calculate yield, XP, and profit related to farming herbs
+#[derive(Debug, StructOpt)]
+pub struct CalcFarmHerbCommand {
+    /// Farming level (affects crop yield)
+    #[structopt(short = "l", long = "lvl")]
+    farming_level: Option<u32>,
+}
+
+impl Command for CalcFarmHerbCommand {
+    fn execute(&self, context: &CommandContext) -> anyhow::Result<()> {
+        let herb_cfg = &context.config().farming.herbs;
+
+        // Make sure at least one patch is configured
+        if herb_cfg.patches.is_empty() {
+            return Err(OsrsError::Unconfigured {
+                key: "farming.herbs.patches".into(),
+                message: "Configure your herb patches to use this calculator."
+                    .into(),
+            }
+            .into());
+        }
+
+        // Calculate expected results for each patch
+        // TODO grab farming level from hiscores when possible
+        let farming_level = self.farming_level.unwrap_or(1);
+
+        // Print a little prelude to give the user some info
+        println!("All values are an average across all patches. Yield values take into account survival chance.");
+        println!();
+        println!("Farming level: {}", farming_level);
+        println!("{}", &herb_cfg);
+
+        let mut table = Table::new();
+        table.set_format(
+            *prettytable::format::consts::FORMAT_NO_LINESEP_WITH_TITLE,
+        );
+        table.set_titles(row!["Herb", r->"Survival Chance", r->"Yield per Seed", r->"XP per Seed"]);
+
+        for herb in Herb::iter() {
+            let herb_stats =
+                calc_average_patch_stats(farming_level, herb_cfg, herb);
+            // TODO include price data here
+            table.add_row(row![
+                herb.to_string(),
+                r->fmt::fmt_probability(herb_stats.survival_chance),
+                r->format!("{:.2}", herb_stats.expected_yield),
+                r->format!("{:.1}", herb_stats.expected_xp),
+            ]);
+        }
+
+        table.printstd();
+        Ok(())
+    }
+}
+
+/// Calculate output statistics for *all* patches and average them together.
+/// Most players plant the same herb in all patches, so a simple average works
+/// for that case to give average yield/profit numbers.
+///
+/// If you really want to min/max you could plant different herbs in different
+/// patches but this function ignores those weenies.
+fn calc_average_patch_stats(
+    farming_level: u32,
+    herb_cfg: &FarmingHerbsConfig,
+    herb: Herb,
+) -> PatchStats {
+    herb_cfg
+        .patches
+        .iter()
+        .map(|patch| patch.calc_patch_stats(farming_level, herb_cfg, herb))
+        .sum::<PatchStats>()
+        / (herb_cfg.patches.len() as f64)
+}
+
+impl FarmingHerbsConfig {
+    /// Get the number of "harvest lives" that each patch has. This is dependent
+    /// solely on the type of compost used, and we assume that all patches are
+    /// using the same compost, as defined in the config.
+    ///
+    /// See https://oldschool.runescape.wiki/w/Farming#Variable_crop_yield
+    fn harvest_lives(&self) -> u32 {
+        match self.compost {
+            None => 3,
+            Some(Compost::Normal) => 4,
+            Some(Compost::Supercompost) => 5,
+            Some(Compost::Ultracompost) => 6,
+        }
+    }
+
+    /// Calculate the "chance to save" bonus based on **equipped items** only.
+    ///
+    /// See https://oldschool.runescape.wiki/w/Farming#Variable_crop_yield
+    fn calc_item_chance_to_save(&self) -> f64 {
+        let mut bonus = 0.0;
+        if self.magic_secateurs {
+            bonus += 0.1;
+        }
+        if self.farming_cape {
+            bonus += 0.05;
+        }
+        bonus
+    }
+}
+
+impl Display for FarmingHerbsConfig {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        writeln!(
+            f,
+            "Magic secateurs: {}",
+            fmt::fmt_bool(self.magic_secateurs)
+        )?;
+        writeln!(f, "Farming cape: {}", fmt::fmt_bool(self.farming_cape))?;
+        writeln!(
+            f,
+            "Bottomless bucket: {}",
+            fmt::fmt_bool(self.bottomless_bucket)
+        )?;
+        writeln!(f, "Compost: {}", fmt::fmt_option(self.compost))?;
+        writeln!(f, "Anima plant: {}", fmt::fmt_option(self.anima_plant))?;
+        // TODO include brief info on each patch (yield+XP bonus and disease
+        // free)
+        writeln!(
+            f,
+            "Patches: {}",
+            self.patches
+                .iter()
+                .map(|patch| patch.name.as_str())
+                .collect::<Vec<_>>()
+                .join(", ")
+        )?;
+        Ok(())
+    }
+}
+
+impl HerbPatch {
+    /// The odds that an herb growing in this patch survives from seed to
+    /// adulthood, assuming it is not monitored at all
+    fn calc_survival_chance(&self, herb_cfg: &FarmingHerbsConfig) -> f64 {
+        // https://oldschool.runescape.wiki/w/Disease_(Farming)#Reducing_disease_risk
+        let disease_chance_per_cycle = if self.disease_free {
+            0.0
+        } else {
+            // TODO include Iasor logic
+            match herb_cfg.compost {
+                None => 27.0 / 128.0,
+                Some(Compost::Normal) => 14.0 / 128.0,
+                Some(Compost::Supercompost) => 6.0 / 128.0,
+                Some(Compost::Ultracompost) => 3.0 / 128.0,
+            }
+        };
+
+        // All herbs have 4 growth cycles, and we want to find the chance of
+        // exactly 0 disease instances in 4 trials
+        // https://oldschool.runescape.wiki/w/Seeds#Herb_seeds
+        math::binomial(disease_chance_per_cycle, 4, 0)
+    }
+
+    /// Calculate the chance to "save a life" when picking an herb. This is
+    /// variable based on the herb, farming level, and applicable yield bonuses.
+    ///
+    /// See https://oldschool.runescape.wiki/w/Farming#Variable_crop_yield
+    fn calc_chance_to_save(
+        &self,
+        herb_cfg: &FarmingHerbsConfig,
+        farming_level: u32,
+        herb: Herb,
+    ) -> f64 {
+        let item_bonus = herb_cfg.calc_item_chance_to_save();
+        let diary_bonus = self.yield_bonus_pct as f64 / 100.0;
+        let attas_bonus = match herb_cfg.anima_plant {
+            Some(AnimaPlant::Attas) => 0.05,
+            _ => 0.0,
+        };
+
+        let (chance1, chance99) = herb.chance_to_save();
+
+        // This comes straight from the wiki, it's a lot easier to read in
+        // their formatting
+        ((chance1 * (99.0 - farming_level as f64) / 98.0)
+            + (chance99 * (farming_level as f64 - 1.0) / 98.0)
+                * (1.0 + item_bonus)
+                // I'm not *100%* sure that this is the correct place to add
+                // Attas since it doesn't say on the Wiki but let's try it
+                // TODO dig through the calculator code to figure out what it does
+                // https://oldschool.runescape.wiki/w/Calculator:Farming/Herbs/Template?action=edit
+                * (1.0 + diary_bonus + attas_bonus)
+            + 1.0)
+            / 256.0
+    }
+
+    /// Calculate the expected yield of this patch, **assuming it is fully
+    /// grown**. I.e., this **doesn't** take into account the chance of the
+    /// patch dying before adulthood.
+    fn calc_expected_yield(
+        &self,
+        herb_cfg: &FarmingHerbsConfig,
+        farming_level: u32,
+        herb: Herb,
+    ) -> f64 {
+        herb_cfg.harvest_lives() as f64
+            / (1.0 - self.calc_chance_to_save(herb_cfg, farming_level, herb))
+    }
+
+    /// Calculate stats (survival chance, yield, etc.) for this patch given
+    /// some info on the player/herb. Yield and XP values here **do** take into
+    /// account the survival chance.
+    fn calc_patch_stats(
+        &self,
+        farming_level: u32,
+        herb_cfg: &FarmingHerbsConfig,
+        herb: Herb,
+    ) -> PatchStats {
+        let survival_chance = self.calc_survival_chance(herb_cfg);
+        // IMPORTANT: We multiply by survival chance here to account for lost
+        // patches.
+        let expected_yield =
+            self.calc_expected_yield(herb_cfg, farming_level, herb)
+                * survival_chance;
+        // TODO include XP for applying compost
+        let expected_xp =
+            herb.xp_per_plant() + herb.xp_per_harvest() * expected_yield;
+
+        PatchStats {
+            survival_chance,
+            expected_yield,
+            expected_xp,
+        }
+    }
+}
+
+/// Statistics on a particular herb+patch combo.
+#[derive(Copy, Clone, Debug, Add, Div, Sum)]
+struct PatchStats {
+    /// The chance of a patch getting to fully growth, i.e. the opposite of the
+    /// chance of it dying of disease.
+    survival_chance: f64,
+    /// Expected yield from a patch, **factoring in the survival chance**.
+    /// E.g. if survival chance is 50% and we expected to get 6 herbs per
+    /// **fully grown** patch, then expected yield will be 3.0.
+    expected_yield: f64,
+    /// Expected amount of XP gained from planting **and** harvesting it,
+    /// **including** the XP for applying compost.
+    expected_xp: f64,
+}
+
+/// The different types of herbs that a player can grow in an herb patch
+#[derive(Copy, Clone, Debug, Display, EnumIter)]
+enum Herb {
+    #[display(fmt = "Guam leaf")]
+    Guam,
+    Marrentill,
+    Tarromin,
+    Harralander,
+    Goutweed,
+    #[display(fmt = "Ranarr weed")]
+    Ranarr,
+    Toadflax,
+    #[display(fmt = "Irit leaf")]
+    Irit,
+    Avantoe,
+    Kwuarm,
+    Snapdragon,
+    Cadantine,
+    Lantadyma,
+    #[display(fmt = "Dwarf weed")]
+    Dwarf,
+    Torstol,
+}
+
+impl Herb {
+    /// Get the "chance to save" for an herb at level 1 and level 99. All other
+    /// level's values can be linearly interpolated from there.
+    ///
+    /// See https://oldschool.runescape.wiki/w/Farming#Variable_crop_yield
+    fn chance_to_save(self) -> (f64, f64) {
+        // Values are ripped from https://oldschool.runescape.wiki/w/Calculator:Farming/Herbs/Template
+        match self {
+            Self::Guam => (25.0, 80.0),
+            Self::Marrentill => (28.0, 80.0),
+            Self::Tarromin => (31.0, 80.0),
+            Self::Harralander => (36.0, 80.0),
+            Self::Goutweed => (39.0, 80.0),
+            Self::Ranarr => (39.0, 80.0),
+            Self::Toadflax => (43.0, 80.0),
+            Self::Irit => (46.0, 80.0),
+            Self::Avantoe => (50.0, 80.0),
+            Self::Kwuarm => (54.0, 80.0),
+            Self::Snapdragon => (57.0, 80.0),
+            Self::Cadantine => (60.0, 80.0),
+            Self::Lantadyma => (64.0, 80.0),
+            Self::Dwarf => (67.0, 80.0),
+            Self::Torstol => (71.0, 80.0),
+        }
+    }
+
+    /// The amount of Farming XP gained for *planting* one seed of this herb
+    fn xp_per_plant(self) -> f64 {
+        match self {
+            Self::Guam => 11.0,
+            Self::Marrentill => 13.5,
+            Self::Tarromin => 16.0,
+            Self::Harralander => 21.5,
+            Self::Goutweed => 105.0,
+            Self::Ranarr => 27.0,
+            Self::Toadflax => 34.0,
+            Self::Irit => 43.0,
+            Self::Avantoe => 54.5,
+            Self::Kwuarm => 69.0,
+            Self::Snapdragon => 87.5,
+            Self::Cadantine => 106.5,
+            Self::Lantadyma => 134.5,
+            Self::Dwarf => 170.5,
+            Self::Torstol => 199.5,
+        }
+    }
+
+    /// The amount of Farming XP gained for *harvesting* one herb
+    fn xp_per_harvest(self) -> f64 {
+        match self {
+            Self::Guam => 12.5,
+            Self::Marrentill => 15.0,
+            Self::Tarromin => 18.0,
+            Self::Harralander => 24.0,
+            Self::Goutweed => 45.0,
+            Self::Ranarr => 30.5,
+            Self::Toadflax => 38.5,
+            Self::Irit => 48.5,
+            Self::Avantoe => 61.5,
+            Self::Kwuarm => 78.0,
+            Self::Snapdragon => 98.5,
+            Self::Cadantine => 120.0,
+            Self::Lantadyma => 151.5,
+            Self::Dwarf => 192.0,
+            Self::Torstol => 224.5,
+        }
+    }
+}

--- a/src/commands/calc/farm/mod.rs
+++ b/src/commands/calc/farm/mod.rs
@@ -1,0 +1,36 @@
+//! This command is a container for additional subcommands related to farming
+//! calculators.
+
+mod herb;
+
+use crate::{
+    commands::{calc::farm::herb::CalcFarmHerbCommand, Command, CommandType},
+    utils::context::CommandContext,
+};
+use structopt::StructOpt;
+
+#[derive(Debug, StructOpt)]
+pub enum CalcFarmCommandType {
+    Herb(CalcFarmHerbCommand),
+}
+
+impl CommandType for CalcFarmCommandType {
+    fn command(&self) -> &dyn Command {
+        match &self {
+            Self::Herb(cmd) => cmd,
+        }
+    }
+}
+
+/// Calculators related to farming
+#[derive(Debug, StructOpt)]
+pub struct CalcFarmCommand {
+    #[structopt(subcommand)]
+    pub cmd: CalcFarmCommandType,
+}
+
+impl Command for CalcFarmCommand {
+    fn execute(&self, context: &CommandContext) -> anyhow::Result<()> {
+        self.cmd.command().execute(context)
+    }
+}

--- a/src/commands/calc/mod.rs
+++ b/src/commands/calc/mod.rs
@@ -2,13 +2,15 @@
 //! calculations.
 
 mod drop;
+mod farm;
 mod stew;
 mod xp;
 
 use crate::{
     commands::{
         calc::{
-            drop::CalcDropCommand, stew::CalcStewCommand, xp::CalcXpCommand,
+            drop::CalcDropCommand, farm::CalcFarmCommand,
+            stew::CalcStewCommand, xp::CalcXpCommand,
         },
         Command, CommandType,
     },
@@ -20,6 +22,7 @@ use structopt::StructOpt;
 pub enum CalcCommandType {
     Drop(CalcDropCommand),
     Stew(CalcStewCommand),
+    Farm(CalcFarmCommand),
     Xp(CalcXpCommand),
 }
 
@@ -28,6 +31,7 @@ impl CommandType for CalcCommandType {
         match &self {
             Self::Drop(cmd) => cmd,
             Self::Stew(cmd) => cmd,
+            Self::Farm(cmd) => cmd,
             Self::Xp(cmd) => cmd,
         }
     }

--- a/src/commands/calc/stew.rs
+++ b/src/commands/calc/stew.rs
@@ -3,7 +3,7 @@ use std::iter;
 use crate::{
     commands::Command,
     error::OsrsError,
-    utils::{context::CommandContext, math},
+    utils::{context::CommandContext, fmt, math},
 };
 use prettytable::{color, format::Alignment, Attr, Cell, Row, Table};
 use structopt::StructOpt;
@@ -81,7 +81,7 @@ impl Command for CalcStewCommand {
                 // Calculate prob for hitting each boost value (1-5)
                 .chain(dose_probabilities.into_iter().map(|(boost, prob)| {
                     let mut cell = Cell::new_align(
-                        &format!("{:.1}%", prob * 100.0),
+                        &fmt::fmt_probability(prob),
                         Alignment::RIGHT,
                     );
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,5 +1,7 @@
 use crate::error::OsrsError;
+use anyhow::Context;
 use config::{Config, File};
+use derive_more::Display;
 use serde::{Deserialize, Serialize};
 
 /// The path to the file where we store configuration.
@@ -9,18 +11,85 @@ pub const CONFIG_FILE_PATH: &str = if cfg!(debug_assertions) {
     "~/.config/osrs.json"
 };
 
-#[derive(Debug, Default, Serialize, Deserialize, PartialEq)]
+#[derive(Clone, Debug, Default, PartialEq, Serialize, Deserialize)]
 pub struct OsrsConfig {
     /// For commands that take a player name, this player will be used when
     /// none is given.
     pub default_player: Option<String>,
+    pub farming: FarmingConfig,
+}
+
+/// Configuration relatd to a player's farm patches
+#[derive(Clone, Debug, Default, PartialEq, Serialize, Deserialize)]
+pub struct FarmingConfig {
+    pub herbs: FarmingHerbsConfig,
+}
+
+/// Configuration related to a player's herb patches
+///
+/// Impls for this type live in [crate::commands::calc::farm::herb].
+#[derive(Clone, Debug, Default, PartialEq, Serialize, Deserialize)]
+pub struct FarmingHerbsConfig {
+    /// The list of herb patches being farmed
+    pub patches: Vec<HerbPatch>,
+    /// The type of compost being used
+    pub compost: Option<Compost>,
+    /// Do you have magic secateurs equipped? (10% yield bonus)
+    pub magic_secateurs: bool,
+    /// Do you have a farming cape equipped? (5% yield bonus)
+    pub farming_cape: bool,
+    /// Do you have a bottomless bucket? Affects cost of compost per patch
+    pub bottomless_bucket: bool,
+    /// The type of Anima plant currently alive at the Farming Guild (can
+    /// affect disease and yield rates)
+    pub anima_plant: Option<AnimaPlant>,
+}
+
+/// Different types of compost that can be applied to a farming patch
+#[derive(Copy, Clone, Debug, Display, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum Compost {
+    Normal,
+    Supercompost,
+    Ultracompost,
+}
+
+/// A type of plant that has global impact on how other crops grow
+/// https://oldschool.runescape.wiki/w/Anima_seed
+#[derive(Copy, Clone, Debug, Display, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum AnimaPlant {
+    /// https://oldschool.runescape.wiki/w/Kronos_seed
+    Kronos,
+    /// Increases yield https://oldschool.runescape.wiki/w/Attas_seed
+    Attas,
+    /// Lowers disease chance https://oldschool.runescape.wiki/w/Iasor_seed
+    Iasor,
+}
+
+/// An herb farming patch. Different patches can have different attributes
+/// based on the user's unlocks.
+// TODO make this an enum for each patch so we can be more restrictive about
+// which stats get which buffs
+#[derive(Clone, Debug, Default, PartialEq, Serialize, Deserialize)]
+pub struct HerbPatch {
+    pub name: String,
+    /// Percentage yield bonus applied to this patch. Should NOT be used for
+    /// global yield bonuses.
+    pub yield_bonus_pct: u32,
+    /// Percentage XP bonus applied to this patch.
+    pub xp_bonus_pct: u32,
+    /// Is this patch guaranteed to be disease-free?
+    pub disease_free: bool,
 }
 
 impl OsrsConfig {
     pub fn load() -> anyhow::Result<Self> {
         let mut s = Config::try_from(&OsrsConfig::default()).unwrap();
         s.merge(File::with_name(CONFIG_FILE_PATH).required(false))?;
-        Ok(s.try_into()?)
+        s.try_into().with_context(|| {
+            format!("Error loading config from file `{}`", CONFIG_FILE_PATH)
+        })
     }
 
     /// Convert a (possibly empty) list of username parts into a username. If

--- a/src/error.rs
+++ b/src/error.rs
@@ -9,4 +9,6 @@ pub enum OsrsError {
     UnknownSkill(String),
     #[error("Invalid level. Must be between 1 and 127, got: {0}")]
     InvalidLevel(usize),
+    #[error("Missing configuration for field `{key}`. {message}")]
+    Unconfigured { key: String, message: String },
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -17,6 +17,7 @@ mod config;
 mod error;
 mod utils;
 
+/// All top-level CLI commands.
 #[derive(Debug, StructOpt)]
 enum OsrsCommandType {
     Calc(CalcCommand),

--- a/src/utils/context.rs
+++ b/src/utils/context.rs
@@ -20,6 +20,7 @@ impl CommandContext {
     }
 
     /// Format the given number. The formatting will be based on locale.
+    // TODO move this into the fmt module
     pub fn fmt_num<T: ToFormattedString>(&self, num: &T) -> String {
         num.to_formatted_string(&self.locale)
     }

--- a/src/utils/fmt.rs
+++ b/src/utils/fmt.rs
@@ -1,0 +1,32 @@
+//! Utilities related to formatting values into strings
+
+use std::fmt::Display;
+
+/// Format a probability value (0 to 1) into a percentage string.
+pub fn fmt_probability(probability: f64) -> String {
+    format!("{:.1}%", probability * 100.0)
+}
+
+/// Format a probability value (0 to 1) into a percentage string, with extra
+/// decimal places.
+pub fn fmt_probability_long(probability: f64) -> String {
+    format!("{:.4}%", probability * 100.0)
+}
+
+/// Format a boolean into a yes/no string
+pub fn fmt_bool(b: bool) -> &'static str {
+    if b {
+        "Yes"
+    } else {
+        "No"
+    }
+}
+
+/// Format an option into a string of either the contained value (if `Some`) or
+/// the string `"None"`.
+pub fn fmt_option<T: Display>(opt: Option<T>) -> String {
+    match opt {
+        Some(value) => value.to_string(),
+        None => "None".to_string(),
+    }
+}

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -1,4 +1,5 @@
 pub mod context;
+pub mod fmt;
 pub mod hiscore;
 pub mod math;
 pub mod skill;


### PR DESCRIPTION
Adds a simple version of the herb farming calculator. There's a lot of TODOs left behind, but this is what we have so far:

```
õ> c run -- calc farm herb -l 93
All values are an average across all patches. Yield values take into account survival chance.

Farming level: 93
Magic secateurs: No
Farming cape: No
Bottomless bucket: No
Compost: None
Anima plant: None
Patches: catherby, hosidius

+-------------+-----------------+----------------+-------------+
| Herb        | Survival Chance | Yield per Seed | XP per Seed |
+-------------+-----------------+----------------+-------------+
| Guam leaf   |           69.4% |           3.04 |        49.0 |
| Marrentill  |           69.4% |           3.05 |        59.2 |
| Tarromin    |           69.4% |           3.05 |        70.9 |
| Harralander |           69.4% |           3.06 |        94.8 |
| Goutweed    |           69.4% |           3.06 |       242.6 |
| Ranarr weed |           69.4% |           3.06 |       120.3 |
| Toadflax    |           69.4% |           3.06 |       151.9 |
| Irit leaf   |           69.4% |           3.07 |       191.7 |
| Avantoe     |           69.4% |           3.07 |       243.3 |
| Kwuarm      |           69.4% |           3.07 |       308.8 |
| Snapdragon  |           69.4% |           3.08 |       390.7 |
| Cadantine   |           69.4% |           3.08 |       476.3 |
| Lantadyma   |           69.4% |           3.09 |       602.0 |
| Dwarf weed  |           69.4% |           3.09 |       763.6 |
| Torstol     |           69.4% |           3.09 |       894.0 |
+-------------+-----------------+----------------+-------------+
```