### PR TITLE
[#46] Add Resurrect Crops option to herb calculator

### DIFF
--- a/src/commands/calc/xp.rs
+++ b/src/commands/calc/xp.rs
@@ -124,8 +124,9 @@ impl CalcXpCommand {
                 player,
                 skill: Some(skill),
             } => {
-                let player = HiscorePlayer::load(
-                    &context.config().get_username(player)?,
+                let player = HiscorePlayer::load_from_args(
+                    context.config(),
+                    player.as_slice(),
                 )?;
                 Ok(player.skill(*skill).xp)
             }

--- a/src/commands/config/set_herb.rs
+++ b/src/commands/config/set_herb.rs
@@ -32,6 +32,10 @@ impl Command for ConfigSetHerbCommand {
             "Bottomless bucket?",
             current_herb_config.bottomless_bucket,
         )?;
+        let resurrect_crops = console::confirm(
+            "Resurrect crops?",
+            current_herb_config.resurrect_crops,
+        )?;
         let compost = console::enum_select::<Compost>(
             "Compost",
             current_herb_config.compost,
@@ -91,6 +95,7 @@ impl Command for ConfigSetHerbCommand {
             bottomless_bucket,
             farming_cape,
             magic_secateurs,
+            resurrect_crops,
             compost,
             anima_plant,
 

--- a/src/commands/hiscore.rs
+++ b/src/commands/hiscore.rs
@@ -15,9 +15,8 @@ pub struct HiscoreCommand {
 
 impl Command for HiscoreCommand {
     fn execute(&self, context: &CommandContext) -> anyhow::Result<()> {
-        let username =
-            context.config().get_username(self.username.as_slice())?;
-        let player = HiscorePlayer::load(&username)?;
+        let player =
+            HiscorePlayer::load_from_args(context.config(), &self.username)?;
 
         // Print a table for skills
         println!("Skills");

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,9 +1,6 @@
-use crate::{
-    error::OsrsError,
-    utils::{
-        diary::AchievementDiaryLevel,
-        farm::{AnimaPlant, Compost, HerbPatch},
-    },
+use crate::utils::{
+    diary::AchievementDiaryLevel,
+    farm::{AnimaPlant, Compost, HerbPatch},
 };
 use anyhow::Context;
 use figment::{
@@ -38,15 +35,17 @@ pub struct FarmingHerbsConfig {
     /// The list of herb patches being farmed
     pub patches: Vec<HerbPatch>,
 
-    // Global-level modifiers, that apply to all patches
-    /// The type of compost being used
-    pub compost: Option<Compost>,
     /// Do you have magic secateurs equipped? (10% yield bonus)
     pub magic_secateurs: bool,
     /// Do you have a farming cape equipped? (5% yield bonus)
     pub farming_cape: bool,
     /// Do you have a bottomless bucket? Affects cost of compost per patch
     pub bottomless_bucket: bool,
+    /// Do you use the Resurrect Crops spell on patches that die?
+    pub resurrect_crops: bool,
+    // Global-level modifiers, that apply to all patches
+    /// The type of compost being used
+    pub compost: Option<Compost>,
     /// The type of Anima plant currently alive at the Farming Guild (can
     /// affect disease and yield rates)
     pub anima_plant: Option<AnimaPlant>,
@@ -124,23 +123,5 @@ impl OsrsConfig {
         write_config(&path, self).with_context(|| {
             format!("Error writing config to file `{}`", path.display())
         })
-    }
-
-    /// Convert a (possibly empty) list of username parts into a username. If
-    /// the array has at least one element, the elements will be appended
-    /// together with spaces between. If not, then we'll fall back to the
-    /// default player defined in the config. If that is not present either,
-    /// then return an arg error.
-    pub fn get_username(&self, username: &[String]) -> anyhow::Result<String> {
-        match (username, &self.default_player) {
-            // No arg provided, empty default - error
-            (&[], None) => {
-                Err(OsrsError::ArgsError("No player given".into()).into())
-            }
-            // No arg provided, but we have a default - use the default
-            (&[], Some(default_player)) => Ok(default_player.clone()),
-            // Arg was provided, return that
-            (&[_, ..], _) => Ok(username.join(" ")),
-        }
     }
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -12,6 +12,9 @@ pub enum OsrsError {
     #[error("Invalid level. Must be between 1 and 127, got: {0}")]
     InvalidLevel(usize),
 
+    #[error("Invalid configuration: {0}")]
+    InvalidConfig(String),
+
     #[error("Missing configuration for field `{key}`. {message}")]
     Unconfigured { key: String, message: String },
 }

--- a/src/utils/hiscore.rs
+++ b/src/utils/hiscore.rs
@@ -1,8 +1,12 @@
 //! Utilities for fetching player data from the OSRS hiscores.
 
-use crate::utils::{
-    http,
-    skill::{Skill, SKILLS},
+use crate::{
+    config::OsrsConfig,
+    error::OsrsError,
+    utils::{
+        http,
+        skill::{Skill, SKILLS},
+    },
 };
 use anyhow::Context;
 use csv::ReaderBuilder;
@@ -173,6 +177,29 @@ impl HiscorePlayer {
         Ok(Self { skills, minigames })
     }
 
+    /// Load a player's stats from a combination of a command line argument
+    /// and the config. If a name was supplied on the command line, use that,
+    /// otherwise fall back to the config. If there's no username present there
+    /// either, then return an error.
+    ///
+    /// This is useful for many commands that accept a `--player` argument.
+    pub fn load_from_args(
+        cfg: &OsrsConfig,
+        username_override: &[String],
+    ) -> anyhow::Result<Self> {
+        let username: String = match (username_override, &cfg.default_player) {
+            // No arg provided, empty default - error
+            (&[], None) => Err(anyhow::Error::from(OsrsError::ArgsError(
+                "No player given".into(),
+            ))),
+            // No arg provided, but we have a default - use the default
+            (&[], Some(default_player)) => Ok(default_player.clone()),
+            // Arg was provided, return that
+            (&[_, ..], _) => Ok(username_override.join(" ")),
+        }?;
+        Self::load(&username)
+    }
+
     /// Get data for a single skill from the player
     pub fn skill(&self, skill: Skill) -> &HiscoreSkill {
         self.skills.get(&skill).unwrap()
@@ -223,6 +250,35 @@ fn load_hiscore_items(username: &str) -> anyhow::Result<Vec<HiscoreItem>> {
         // If any item fails, this whole thing will fail
         .collect::<Result<Vec<HiscoreItem>, csv::Error>>()
         .context("Error parsing hiscore data")
+}
+
+/// A helper function for getting a particular skill level that is overridable
+/// via the command line. Many commands rely on a singular level (e.g. farming
+/// calculators rely on farming level). These commands tend to support passing
+/// the level in a variety of ways:
+/// 1. Directly on the command line
+/// 2. Pass username, look up the level on hiscores
+/// 3. Use username in the config, look up the level on hiscores
+///
+/// This function applies those options, in that order, and returns the
+/// appropriate level. You give this function all the info you got from the
+/// user, and it spits out the level you should use. If none of the three
+/// options are available, return an error.
+pub fn get_level_from_args(
+    cfg: &OsrsConfig,
+    skill: Skill,
+    username_override: &[String],
+    level_override: Option<usize>,
+) -> anyhow::Result<usize> {
+    if let Some(level) = level_override {
+        // Level override was given, use it
+        Ok(level)
+    } else {
+        // Look up by player name. This will try the username override first,
+        // then fall back on the cfg. If neither is present, we'll error out
+        let player = HiscorePlayer::load_from_args(cfg, username_override)?;
+        Ok(player.skill(skill).level)
+    }
 }
 
 #[cfg(test)]

--- a/src/utils/item.rs
+++ b/src/utils/item.rs
@@ -9,6 +9,22 @@ use std::collections::HashMap;
 
 // IDs are pulled from https://www.osrsbox.com/tools/item-search/
 
+pub const ITEM_ID_AIR_RUNE: usize = 556;
+pub const ITEM_ID_WATER_RUNE: usize = 555;
+pub const ITEM_ID_EARTH_RUNE: usize = 557;
+pub const ITEM_ID_FIRE_RUNE: usize = 554;
+pub const ITEM_ID_BODY_RUNE: usize = 559;
+pub const ITEM_ID_MIND_RUNE: usize = 558;
+pub const ITEM_ID_CHAOS_RUNE: usize = 562;
+pub const ITEM_ID_DEATH_RUNE: usize = 560;
+pub const ITEM_ID_BLOOD_RUNE: usize = 565;
+pub const ITEM_ID_WRATH_RUNE: usize = 21880;
+pub const ITEM_ID_COSMIC_RUNE: usize = 564;
+pub const ITEM_ID_NATURE_RUNE: usize = 561;
+pub const ITEM_ID_LAW_RUNE: usize = 563;
+pub const ITEM_ID_ASTRAL_RUNE: usize = 9075;
+pub const ITEM_ID_SOUL_RUNE: usize = 566;
+
 pub const ITEM_ID_COMPOST: usize = 6032;
 pub const ITEM_ID_SUPERCOMPOST: usize = 6034;
 pub const ITEM_ID_ULTRACOMPOST: usize = 21483;

--- a/src/utils/magic.rs
+++ b/src/utils/magic.rs
@@ -1,0 +1,111 @@
+//! Utilities related to magic, runes, and spells
+
+use crate::utils::{
+    item::{self, WIKI_ITEM_CLIENT},
+    math,
+};
+
+/// Runes are used to cast spells
+#[derive(Copy, Clone, Debug)]
+#[allow(dead_code)] // We'll probably need these variants at some point
+pub enum Rune {
+    Air,
+    Water,
+    Earth,
+    Fire,
+    // Deliberate leaving out combo runes, not needed for now
+    Body,
+    Mind,
+    Chaos,
+    Death,
+    Blood,
+    Wrath,
+    Cosmic,
+    Nature,
+    Law,
+    Astral,
+    Soul,
+}
+
+impl Rune {
+    /// Get the ID of the item associated with this rune
+    pub fn item_id(self) -> usize {
+        match self {
+            Self::Air => item::ITEM_ID_AIR_RUNE,
+            Self::Water => item::ITEM_ID_WATER_RUNE,
+            Self::Earth => item::ITEM_ID_EARTH_RUNE,
+            Self::Fire => item::ITEM_ID_FIRE_RUNE,
+            Self::Body => item::ITEM_ID_BODY_RUNE,
+            Self::Mind => item::ITEM_ID_MIND_RUNE,
+            Self::Chaos => item::ITEM_ID_CHAOS_RUNE,
+            Self::Death => item::ITEM_ID_DEATH_RUNE,
+            Self::Blood => item::ITEM_ID_BLOOD_RUNE,
+            Self::Wrath => item::ITEM_ID_WRATH_RUNE,
+            Self::Cosmic => item::ITEM_ID_COSMIC_RUNE,
+            Self::Nature => item::ITEM_ID_NATURE_RUNE,
+            Self::Law => item::ITEM_ID_LAW_RUNE,
+            Self::Astral => item::ITEM_ID_ASTRAL_RUNE,
+            Self::Soul => item::ITEM_ID_SOUL_RUNE,
+        }
+    }
+}
+
+/// Yer a wizard, Harry
+#[derive(Copy, Clone, Debug)]
+pub enum Spell {
+    ResurrectCrops,
+}
+
+impl Spell {
+    /// The level required to cast this spell
+    pub fn level(self) -> usize {
+        match self {
+            Self::ResurrectCrops => 78,
+        }
+    }
+
+    /// Get the runes required to cast this spell, as a mapping of
+    /// rune->quantity
+    pub fn runes(self) -> &'static [(Rune, usize)] {
+        match self {
+            Self::ResurrectCrops => &[
+                (Rune::Earth, 25),
+                (Rune::Nature, 12),
+                (Rune::Blood, 8),
+                (Rune::Soul, 8),
+            ],
+        }
+    }
+
+    /// Get the cost of casting this spell. Assumes all runes are used, i.e.
+    /// no staffs or similar items. Returns an error if a price lookup fails.
+    pub fn rune_cost(self) -> anyhow::Result<usize> {
+        let mut sum = 0;
+        for (rune, quantity) in self.runes() {
+            let price = WIKI_ITEM_CLIENT.get_avg_price(rune.item_id())?;
+            // A rune price lookup should never return nothing as there are no
+            // untradeable runes, but if it does, just consider them free.
+            sum += price.unwrap_or_default() * quantity;
+        }
+        Ok(sum)
+    }
+
+    /// Calculate the chance of success for the Resurrect Crops spell, given
+    /// the player's magic level. Scales from 50% at 78 (required level) to
+    /// 75% at 99.
+    pub fn resurrect_crops_chance(level: usize) -> f64 {
+        let required_level = Self::ResurrectCrops.level();
+        // Can use the spell at all ya fuckin noob
+        if level < required_level {
+            0.0
+        } else {
+            math::map_to_range(
+                level as f64,
+                required_level as f64,
+                99.0,
+                0.50,
+                0.75,
+            )
+        }
+    }
+}

--- a/src/utils/math.rs
+++ b/src/utils/math.rs
@@ -64,6 +64,37 @@ pub fn binomial_cdf(
     }
 }
 
+/// Clamp a value into a fixed range
+pub fn clamp(value: f64, min: f64, max: f64) -> f64 {
+    if value < min {
+        min
+    } else if value > max {
+        max
+    } else {
+        value
+    }
+}
+
+/// Map a value from one range to another. The value will be scaled from the
+/// old range to the new one. For example if you map `12` from `[10, 20]` to
+/// `[1,2]`, you get 1.2. **Values outside the input range will be clamped to
+/// the range during mapping.** This guarantees that the output value will
+/// be in the output range.
+pub fn map_to_range(
+    value: f64,
+    from_start: f64,
+    from_end: f64,
+    to_start: f64,
+    to_end: f64,
+) -> f64 {
+    // Shift+scale to from in the input range to [0,1]
+    let normalized = (value - from_start) / (from_end - from_start);
+    // Force into [0,1]
+    let normalized = clamp(normalized, 0.0, 1.0);
+    // Scale+shift to the output range
+    to_start + normalized * (to_end - to_start)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -6,5 +6,6 @@ pub mod fmt;
 pub mod hiscore;
 pub mod http;
 pub mod item;
+pub mod magic;
 pub mod math;
 pub mod skill;


### PR DESCRIPTION
Adds a new option to the herb calculator for casting Resurrect Crops on all herbs that die. This calculates the increase in survival chance due to the spell (and subsequent increase in yield), as well as the cost of the runes for the spell.