### PR TITLE
Upgrade to Rust nightly 2021-12-10

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,7 +51,7 @@ jobs:
       matrix:
         # If you update stable, make sure to update Cargo.toml
         # If you update nightly, make sure to update rust-toolchain.toml
-        rust: ["1.56", nightly-2021-10-06]
+        rust: ["1.56", nightly-2021-12-10]
     env:
       # This overrides rust-toolchain.toml
       RUSTUP_TOOLCHAIN: ${{ matrix.rust }}

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -467,7 +467,6 @@ dependencies = [
  "thiserror",
  "ureq",
  "urlencoding",
- "version_check",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,6 +37,3 @@ urlencoding = "^2.1.0"
 
 [dev-dependencies]
 assert_approx_eq = "^1.1.0"
-
-[build-dependencies]
-version_check = "^0.9.2"

--- a/build.rs
+++ b/build.rs
@@ -1,6 +1,0 @@
-fn main() {
-    println!("cargo:rerun-if-changed=build.rs");
-    if version_check::is_feature_flaggable().unwrap_or(false) {
-        println!("cargo:rustc-cfg=nightly");
-    }
-}

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,4 +1,4 @@
 [toolchain]
 # If you update this, make sure to update the version used in ci.yml
-channel = "nightly-2021-10-06"
+channel = "nightly-2021-12-10"
 components = ["cargo", "clippy", "rustfmt"]

--- a/src/utils/item.rs
+++ b/src/utils/item.rs
@@ -105,7 +105,7 @@ impl WikiItemClient {
         &self,
         item_id: usize,
     ) -> anyhow::Result<Option<usize>> {
-        Ok(self.get_price(item_id)?.map(|price| price.avg()).flatten())
+        Ok(self.get_price(item_id)?.and_then(|price| price.avg()))
     }
 
     /// Search items by name. This will do a caseless substring match, and


### PR DESCRIPTION
Also remove the build.rs. Apparently we needed it to make it compile on stable, but not anymore ¯\_(ツ)_/¯