### PR TITLE
2.0.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -688,7 +688,7 @@ dependencies = [
 
 [[package]]
 name = "osrs-cli"
-version = "2.0.0"
+version = "2.0.1"
 dependencies = [
  "anyhow",
  "assert_approx_eq",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ name = "osrs-cli"
 repository = "https://github.com/LucasPickering/osrs-cli"
 # If you update this, make sure to update the version used in ci.yml
 rust-version = "1.58"
-version = "2.0.0"
+version = "2.0.1"
 
 [lib]
 crate-type = ["cdylib", "rlib"] # Needed for wasm


### PR DESCRIPTION
Fixes the `hiscore` subcommand to use the official API instead of the one I homerolled. My own API hasn't been running for years so the command has just been broken.